### PR TITLE
Move common handlers to server package

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/slack-go/slack/slackevents"
+	"go.uber.org/zap"
+)
+
+type Handler interface {
+	SetLogger(logger *zap.Logger)
+	Handle(w http.ResponseWriter, event *slackevents.EventsAPIEvent) error
+}
+
+type BaseHandler struct {
+	log *zap.Logger
+}
+
+func (h *BaseHandler) SetLogger(logger *zap.Logger) {
+	h.log = logger
+}

--- a/server/callback_event_handler.go
+++ b/server/callback_event_handler.go
@@ -1,9 +1,11 @@
-package handler
+package server
 
 import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/hirakiuc/gonta-app/handler"
 
 	"github.com/slack-go/slack/slackevents"
 	"go.uber.org/zap"
@@ -25,7 +27,7 @@ func (h *CallbackEventHandler) Handle(w http.ResponseWriter, event *slackevents.
 	innerEvent := event.InnerEvent
 	switch ev := innerEvent.Data.(type) {
 	case *slackevents.AppMentionEvent:
-		handler := NewMentionHandler()
+		handler := handler.NewMentionHandler()
 		handler.SetLogger(log)
 
 		return handler.Handle(w, event, ev)

--- a/server/gonta.go
+++ b/server/gonta.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/hirakiuc/gonta-app/handler"
-
 	"github.com/slack-go/slack/slackevents"
 	"go.uber.org/zap"
 )
@@ -78,14 +76,14 @@ func getVerificationToken() string {
 	return os.Getenv("VERIFICATION_TOKEN")
 }
 
-func (s *Gonta) handlerByEventType(eventType string) (handler.Handler, error) {
+func (s *Gonta) handlerByEventType(eventType string) (Handler, error) {
 	log := s.log
 
 	switch eventType {
 	case slackevents.URLVerification:
-		return handler.NewURLVerificationHandler(), nil
+		return NewURLVerificationHandler(), nil
 	case slackevents.CallbackEvent:
-		return handler.NewCallbackEventHandler(), nil
+		return NewCallbackEventHandler(), nil
 	default:
 		log.Error("Unexpected event type", zap.String("type", eventType))
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,4 +1,4 @@
-package handler
+package server
 
 import (
 	"net/http"

--- a/server/url_verification_handler.go
+++ b/server/url_verification_handler.go
@@ -1,4 +1,4 @@
-package handler
+package server
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Move common handlers to server package to prepare for extending handlers
