### PR TITLE
support only post request on actions endpoint

### DIFF
--- a/server/gonta.go
+++ b/server/gonta.go
@@ -149,6 +149,13 @@ func (s *Gonta) ServeEvents(w http.ResponseWriter, r *http.Request) {
 func (s *Gonta) ServeActions(w http.ResponseWriter, r *http.Request) {
 	log := s.log
 
+	if r.Method != http.MethodPost {
+		log.Debug("Invalid http method", zap.String("method", r.Method))
+		w.WriteHeader(http.StatusMethodNotAllowed)
+
+		return
+	}
+
 	var payload *slack.InteractionCallback
 
 	err := json.Unmarshal([]byte(r.FormValue("payload")), &payload)


### PR DESCRIPTION
# WHAT

- Support only POST request on actions endpoint.

# WHY

- To follow the slack API spec.

> Slack will send an HTTP POST request with information to this URL when users interact with a shortcut or interactive component.
